### PR TITLE
Sort service nodes on block height of last reward, oldest first.

### DIFF
--- a/lib/src/screens/dashboard_page.dart
+++ b/lib/src/screens/dashboard_page.dart
@@ -91,6 +91,8 @@ class DashboardPage extends BasePage {
               : S.of(context).health_out_of_nodes(
                   operatorStatus.healthyNodes, operatorStatus.totalNodes));
 
+      nodeSyncStatus.nodes.sort((a, b) => a.lastReward.blockHeight.compareTo(b.lastReward.blockHeight));
+
       return ListView(
         shrinkWrap: true,
         children: [


### PR DESCRIPTION
# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dartfmt -w lib´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users


## Issues affected
This patch will sort the service node list by position in the queue for the next reward.