### PR TITLE
Check whether checkpoints and pulses actually exist before reading them.

### DIFF
--- a/lib/src/oxen/service_node_status.dart
+++ b/lib/src/oxen/service_node_status.dart
@@ -156,7 +156,7 @@ class CheckpointParticipation {
   CheckpointParticipation(this.checkpoints);
 
   CheckpointParticipation.fromMap(Map map)
-      : checkpoints = (map['active']
+      : checkpoints = (map.containsKey('checkpoint_participation')
             ? (map['checkpoint_participation'] as List)
                 .map((e) => Checkpoint.fromMap(e))
                 .toList()
@@ -180,7 +180,7 @@ class PulseParticipation {
   PulseParticipation(this.pulses);
 
   PulseParticipation.fromMap(Map map)
-      : pulses = (map['active']
+      : pulses = (map.containsKey('pulse_participation')
             ? (map['pulse_participation'] as List)
                 .map((e) => Pulse.fromMap(e))
                 .toList()


### PR DESCRIPTION
This fixes a problem that would probably occur if the user added a
recently activated node that hasn't yet participated in any checkpoints
or pulses. This would likely cause an exception that prevented the whole
dashboard from being displayed until at least one checkpoint and one
pulse had been participated in.

If `checkpoint_participation` and `pulse_participation` are empty arrays in the RPC data of such hosts, there would be no issue, but if those elements don't even occur in the returned data, then this patch will be needed.

Even if it's not needed, this is the mode logical check to carry out.

# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dartfmt -w lib´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users

