### PR TITLE
Display last state change height and approximate registration date.

### DIFF
--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -89,6 +89,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "settings_title_app" : MessageLookupByLibrary.simpleMessage("App"),
     "settings_title_general" : MessageLookupByLibrary.simpleMessage("Generelle Einstellungen"),
     "software_versions" : MessageLookupByLibrary.simpleMessage("Node / Storage Server / Lokinet Version"),
+    "state_height" : MessageLookupByLibrary.simpleMessage("Letzte Zustandsänderung Höhe"),
     "storage_server" : MessageLookupByLibrary.simpleMessage("Storage Server"),
     "swarm_id" : MessageLookupByLibrary.simpleMessage("Swarm ID"),
     "title_add_daemon" : MessageLookupByLibrary.simpleMessage("Daemon hinzufügen"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -92,6 +92,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "settings_title_app" : MessageLookupByLibrary.simpleMessage("App"),
     "settings_title_general" : MessageLookupByLibrary.simpleMessage("General"),
     "software_versions" : MessageLookupByLibrary.simpleMessage("Node / Storage Server / Lokinet Version"),
+    "state_height" : MessageLookupByLibrary.simpleMessage("Last State Change Height"),
     "storage_server" : MessageLookupByLibrary.simpleMessage("Storage Server"),
     "swarm_id" : MessageLookupByLibrary.simpleMessage("Swarm ID"),
     "title_add_daemon" : MessageLookupByLibrary.simpleMessage("Add Daemon"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -305,6 +305,16 @@ class S {
     );
   }
 
+  /// `Last State Change Height`
+  String get state_height {
+    return Intl.message(
+      'Last State Change Height',
+      name: 'state_height',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Earned Downtime Blocks`
   String get earned_downtime_blocks {
     return Intl.message(

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -43,6 +43,7 @@
   "copied_to_clipboard": "{title} in die Zwischenablage kopiert",
   "checkpoints": "Checkpoint Blöcke",
   "pulses": "Pulse Blöcke",
+  "state_height": "Letzte Zustandsänderung Höhe",
 
   "hours": "Stunden",
   "minutes_ago": "vor {minutes} Minuten",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -45,6 +45,7 @@
   "copied_to_clipboard": "Copied {title} to clipboard",
   "checkpoints": "Checkpoints",
   "pulses": "Pulses",
+  "state_height": "Last State Change Height",
 
   "hours": "hours",
   "minutes_ago": "{minutes} minutes ago",

--- a/lib/src/screens/details_service_node_page.dart
+++ b/lib/src/screens/details_service_node_page.dart
@@ -32,6 +32,11 @@ class DetailsServiceNodePage extends BasePage {
     );
   }
 
+  DateTime estimatePastDateForHeight(int height) {
+    return DateTime.now()
+        .subtract(Duration(minutes: height * AVERAGE_BLOCK_MINUTES));
+  }
+
   DateTime estimateFutureDateForHeight(int expectedAddedBlocks) {
     return DateTime.now()
         .add(Duration(minutes: expectedAddedBlocks * AVERAGE_BLOCK_MINUTES));
@@ -194,7 +199,9 @@ class DetailsServiceNodePage extends BasePage {
                     forceSmallText: true),
                 Padding(padding: EdgeInsets.only(top: 15.0), child: Divider()),
                 NavListMultiHeader(S.of(context).registration_height,
-                    '${node.nodeInfo.registrationHeight}'),
+                    '${node.nodeInfo.registrationHeight} (~ ${DateFormat.yMMMd(localeName).add_jm().format(estimatePastDateForHeight(nodeSyncStatus.currentHeight - node.nodeInfo.registrationHeight))})'),
+                NavListMultiHeader(S.of(context).state_height,
+                    '${node.stateHeight} (~ ${DateFormat.yMMMd(localeName).add_jm().format(estimatePastDateForHeight(nodeSyncStatus.currentHeight - node.stateHeight))})'),
                 NavListMultiHeader(S.of(context).registration_hf_version,
                     '${node.nodeInfo.registrationHfVersion}'),
                 NavListMultiHeader(S.of(context).software_versions,


### PR DESCRIPTION
# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dartfmt -w lib´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users


## Issues affected
We can now display the height of the last state change (which will be the same as the registration height if the node has always been `active`), plus the approximate time that the block was mined.

For good measure, we also display the approximate time that the node registration block was mined.