### PR TITLE
Use `dart format` instead of deprecated `dartfmt -w`.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 * [ ] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
 * [ ] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
-* [ ] Ran ´dartfmt -w lib/src´
+* [ ] Ran ´dart format lib/src´
 * [ ] All tests are passing
 * [ ] My changes are ready to be shipped to users
 


### PR DESCRIPTION
# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dartfmt -w lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users

