### PR TITLE
Display approximate time of last reward.

### DIFF
--- a/lib/src/screens/details_service_node_page.dart
+++ b/lib/src/screens/details_service_node_page.dart
@@ -123,7 +123,7 @@ class DetailsServiceNodePage extends BasePage {
                   ),
                 ),
                 NavListMultiHeader(S.of(context).last_reward_height,
-                    '${node.lastReward.blockHeight}'),
+                    '${node.lastReward.blockHeight} (~ ${DateFormat.yMMMd(localeName).add_jm().format(estimatePastDateForHeight(nodeSyncStatus.currentHeight - node.lastReward.blockHeight))})'),
                 NavListMultiHeader(S.of(context).last_uptime_proof,
                     '${DateFormat.yMMMd(localeName).add_jms().format(node.lastUptimeProof)} (${S.of(context).minutes_ago(DateTime.now().difference(node.lastUptimeProof).inMinutes)})'),
                 NavListMultiHeader(S.of(context).earned_downtime_blocks,


### PR DESCRIPTION
# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dart format lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users


## Issues affected
We may as well reflect the time of the last reward, as it's now the only displayed block height that we don't also express as a time.