### PR TITLE
Give hours of earned downtime blocks to 2 decimal places.

### DIFF
--- a/lib/src/screens/details_service_node_page.dart
+++ b/lib/src/screens/details_service_node_page.dart
@@ -127,7 +127,7 @@ class DetailsServiceNodePage extends BasePage {
                 NavListMultiHeader(S.of(context).last_uptime_proof,
                     '${DateFormat.yMMMd(localeName).add_jms().format(node.lastUptimeProof)} (${S.of(context).minutes_ago(DateTime.now().difference(node.lastUptimeProof).inMinutes)})'),
                 NavListMultiHeader(S.of(context).earned_downtime_blocks,
-                    '${node.earnedDowntimeBlocks} / $DECOMMISSION_MAX_CREDIT (${(node.earnedDowntimeBlocks / 60 * AVERAGE_BLOCK_MINUTES).toStringAsFixed(0)} ${S.of(context).hours})'),
+                    '${node.earnedDowntimeBlocks} / $DECOMMISSION_MAX_CREDIT (${(node.earnedDowntimeBlocks / 60 * AVERAGE_BLOCK_MINUTES).toStringAsFixed(2)} ${S.of(context).hours})'),
                 if (node.active)
                   Center(
                       child: Column(


### PR DESCRIPTION
# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dart format lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users


## Issues affected

`oxend` gives hours of earned downtime to 2 decimal places, so we should, too.