### PR TITLE
Deal with case of node having sent no recent uptime proof.

### DIFF
--- a/lib/src/screens/details_service_node_page.dart
+++ b/lib/src/screens/details_service_node_page.dart
@@ -125,7 +125,7 @@ class DetailsServiceNodePage extends BasePage {
                 NavListMultiHeader(S.of(context).last_reward_height,
                     '${node.lastReward.blockHeight} (~ ${DateFormat.yMMMd(localeName).add_jm().format(estimatePastDateForHeight(nodeSyncStatus.currentHeight - node.lastReward.blockHeight))})'),
                 NavListMultiHeader(S.of(context).last_uptime_proof,
-                    '${DateFormat.yMMMd(localeName).add_jms().format(node.lastUptimeProof)} (${S.of(context).minutes_ago(DateTime.now().difference(node.lastUptimeProof).inMinutes)})'),
+                    node.lastUptimeProof.millisecondsSinceEpoch == 0 ? '-' : '${DateFormat.yMMMd(localeName).add_jms().format(node.lastUptimeProof)} (${S.of(context).minutes_ago(DateTime.now().difference(node.lastUptimeProof).inMinutes)})'),
                 NavListMultiHeader(S.of(context).earned_downtime_blocks,
                     '${node.earnedDowntimeBlocks} / $DECOMMISSION_MAX_CREDIT (${(node.earnedDowntimeBlocks / 60 * AVERAGE_BLOCK_MINUTES).toStringAsFixed(2)} ${S.of(context).hours})'),
                 if (node.active)


### PR DESCRIPTION
When this is the case, the timestamp will be 0, so we need to avoid
converting this to the start of the UNIX epoch.

# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dart format lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users
