### PR TITLE
Add number of contributors to dashboard entries.

### DIFF
--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -41,6 +41,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "all_service_nodes" : m0,
     "blocks" : MessageLookupByLibrary.simpleMessage("Blöcke"),
     "checkpoints" : MessageLookupByLibrary.simpleMessage("Checkpoint Blöcke"),
+    "contributors" : MessageLookupByLibrary.simpleMessage("Beiträger"),
     "copied_to_clipboard" : m1,
     "daemon_address" : MessageLookupByLibrary.simpleMessage("Daemon Adresse"),
     "daemon_port" : MessageLookupByLibrary.simpleMessage("Daemon Port"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -43,6 +43,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "all_service_nodes" : m0,
     "blocks" : MessageLookupByLibrary.simpleMessage("blocks"),
     "checkpoints" : MessageLookupByLibrary.simpleMessage("Checkpoints"),
+    "contributors" : MessageLookupByLibrary.simpleMessage("Contributors"),
     "copied_to_clipboard" : m1,
     "daemon_address" : MessageLookupByLibrary.simpleMessage("Daemon Address"),
     "daemon_port" : MessageLookupByLibrary.simpleMessage("Daemon Port"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -794,6 +794,16 @@ class S {
       args: [],
     );
   }
+
+  /// `Contributors`
+  String get contributors {
+    return Intl.message(
+      'Contributors',
+      name: 'contributors',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -49,6 +49,7 @@
   "checkpoints": "Checkpoint Blöcke",
   "pulses": "Pulse Blöcke",
   "state_height": "Letzte Zustandsänderung Höhe",
+  "contributors": "Beiträger",
 
   "hours": "Stunden",
   "minutes_ago": "vor {minutes} Minuten",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -51,6 +51,7 @@
   "checkpoints": "Checkpoints",
   "pulses": "Pulses",
   "state_height": "Last State Change Height",
+  "contributors": "Contributors",
 
   "hours": "hours",
   "minutes_ago": "{minutes} minutes ago",

--- a/lib/src/screens/dashboard_page.dart
+++ b/lib/src/screens/dashboard_page.dart
@@ -163,7 +163,8 @@ class DashboardPage extends BasePage {
                     nodeStatus.lokinetRouter.isReachable,
                     nodeStatus.lastReward.blockHeight,
                     nodeStatus.earnedDowntimeBlocks,
-                    nodeStatus.lastUptimeProof);
+                    nodeStatus.lastUptimeProof,
+                    nodeStatus.contribution);
               }),
         ],
       );

--- a/lib/src/widgets/service_node_card.dart
+++ b/lib/src/widgets/service_node_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:oxen_service_node/generated/l10n.dart';
 import 'package:oxen_service_node/src/utils/router/oxen_routes.dart';
 import 'package:oxen_service_node/src/utils/theme/palette.dart';
+import 'package:oxen_service_node/src/oxen/service_node_status.dart';
 
 class ServiceNodeCard extends StatefulWidget {
   ServiceNodeCard(
@@ -15,7 +16,8 @@ class ServiceNodeCard extends StatefulWidget {
       this.isLokinetRouterReachable,
       this.lastRewardBlockHeight,
       this.earnedDowntimeBlocks,
-      this.lastUptimeProof);
+      this.lastUptimeProof,
+      this.contribution);
 
   final String name;
   final String serviceNodeKey;
@@ -26,6 +28,7 @@ class ServiceNodeCard extends StatefulWidget {
   final int lastRewardBlockHeight;
   final int earnedDowntimeBlocks;
   final DateTime lastUptimeProof;
+  final Contribution contribution;
 
   final localeName = Platform.localeName; // Hack to fix Local 'built' has not been initialized
 
@@ -49,9 +52,17 @@ class _ServiceNodeCardState extends State<ServiceNodeCard> {
     final lastRewardBlockHeight = widget.lastRewardBlockHeight;
     final isStorageServerReachable = widget.isStorageServerReachable;
     final isLokinetRouterReachable = widget.isLokinetRouterReachable;
+    final contribution = widget.contribution;
 
     final serviceNodeKeyShort =
         '${serviceNodeKey.substring(0, 12)}...${serviceNodeKey.substring(serviceNodeKey.length - 4)}';
+    final partiallyStaked = contribution.totalContributed / 1000000000 < 15000;
+    final remainingContribution = partiallyStaked
+      ? ' (${(contribution.totalContributed / 1000000000).toInt()} / 15000 OXEN)'
+      : '';
+    final earnedDowntimeBlocksDisplay = partiallyStaked
+      ? ''
+      : ' ($earnedDowntimeBlocks / $DECOMMISSION_MAX_CREDIT ${S.of(context).blocks})';
     final statusIcon = isUnlocking
         ? Icon(Icons.access_time_sharp, color: OxenPalette.orange, size: 30)
         : (active
@@ -76,7 +87,7 @@ class _ServiceNodeCardState extends State<ServiceNodeCard> {
               fontSize: 18,
               color: Theme.of(context).primaryTextTheme.caption.color)),
       subtitle: Text(
-          '$serviceNodeKeyShort\n${S.of(context).uptime_proof}: ${lastUptimeProof.millisecondsSinceEpoch == 0 ? '-' : S.of(context).minutes_ago(DateTime.now().difference(lastUptimeProof).inMinutes)} ($earnedDowntimeBlocks / $DECOMMISSION_MAX_CREDIT ${S.of(context).blocks})',
+          '$serviceNodeKeyShort\n${S.of(context).uptime_proof}: ${lastUptimeProof.millisecondsSinceEpoch == 0 ? '-' : S.of(context).minutes_ago(DateTime.now().difference(lastUptimeProof).inMinutes)}${earnedDowntimeBlocksDisplay}\n${S.of(context).contributors}: ${contribution.contributors.length}${remainingContribution}',
           style: TextStyle(
               fontSize: 13,
               height: 1.5,


### PR DESCRIPTION
For nodes not yet fully staked (and thus not yet active), we also display the amount of OXEN currently staked and suppress the display of uptime credit.

# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dart format lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users

A future patch will add full contributor information to the service node details page.