### PR TITLE
Use a new, less dramatic icon for a node awaiting contributions.

### DIFF
--- a/lib/src/utils/theme/palette.dart
+++ b/lib/src/utils/theme/palette.dart
@@ -70,5 +70,6 @@ class OxenPalette {
   // Default
   static const Color red = Color.fromRGBO(255, 51, 51, 1.0);
   static const Color orange = Color.fromRGBO(255, 170, 21, 1.0);
+  static const Color yellow = Color.fromRGBO(255, 255, 0, 1.0);
   static const Color green = Color.fromRGBO(39, 206, 80, 1.0);
 }

--- a/lib/src/widgets/service_node_card.dart
+++ b/lib/src/widgets/service_node_card.dart
@@ -64,11 +64,14 @@ class _ServiceNodeCardState extends State<ServiceNodeCard> {
       ? ''
       : ' ($earnedDowntimeBlocks / $DECOMMISSION_MAX_CREDIT ${S.of(context).blocks})';
     final statusIcon = isUnlocking
-        ? Icon(Icons.access_time_sharp, color: OxenPalette.orange, size: 30)
+        ? Icon(Icons.lock_clock_sharp, color: OxenPalette.orange, size: 30)
         : (active
             ? Icon(Icons.check_circle_sharp,
                 color: OxenPalette.iceBlue, size: 30)
-            : Icon(Icons.error_sharp, color: OxenPalette.red, size: 30));
+	    : partiallyStaked
+		? Icon(Icons.people_sharp,
+		  color: OxenPalette.yellow, size: 30)
+		: Icon(Icons.error_sharp, color: OxenPalette.red, size: 30));
 
     return Card(
         child: ExpansionTile(


### PR DESCRIPTION
Also replace icon of unlocking node with padlock + clock.

# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dart format lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users


## Issues affected

A big red exclamation mark denotes a serious issue. This is what we display when a node is decommissioned, for example.

When a node is still awaiting contributions, we now instead display a yellow icon picturing people, indicating that we are waiting for others.

I also found a more suggestive icon for the node unlocking state and substituted that.