### PR TITLE
Don't show bogus next reward for nodes still awaiting contributions.

### DIFF
--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -41,6 +41,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "address" : MessageLookupByLibrary.simpleMessage("Spender"),
     "all_service_nodes" : m0,
     "amount" : MessageLookupByLibrary.simpleMessage("Betrag"),
+    "awaiting_contributions" : MessageLookupByLibrary.simpleMessage("Warten auf Beiträge"),
     "blocks" : MessageLookupByLibrary.simpleMessage("Blöcke"),
     "checkpoints" : MessageLookupByLibrary.simpleMessage("Checkpoint Blöcke"),
     "contributors" : MessageLookupByLibrary.simpleMessage("Beiträger"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -43,6 +43,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "address" : MessageLookupByLibrary.simpleMessage("Staker"),
     "all_service_nodes" : m0,
     "amount" : MessageLookupByLibrary.simpleMessage("Amount"),
+    "awaiting_contributions" : MessageLookupByLibrary.simpleMessage("Awaiting Contributions"),
     "blocks" : MessageLookupByLibrary.simpleMessage("blocks"),
     "checkpoints" : MessageLookupByLibrary.simpleMessage("Checkpoints"),
     "contributors" : MessageLookupByLibrary.simpleMessage("Contributors"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -824,6 +824,16 @@ class S {
       args: [],
     );
   }
+ 
+  /// `Awaiting Contributions`
+  String get awaiting_contributions {
+    return Intl.message(
+      'Awaiting Contributions',
+      name: 'awaiting_contributions',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -52,6 +52,7 @@
   "contributors": "Beiträger",
   "address": "Spender",
   "amount": "Betrag",
+  "awaiting_contributions": "Warten auf Beiträge"
 
   "hours": "Stunden",
   "minutes_ago": "vor {minutes} Minuten",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -54,6 +54,7 @@
   "contributors": "Contributors",
   "address": "Staker",
   "amount": "Amount",
+  "awaiting_contributions": "Awaiting Contributions",
 
   "hours": "hours",
   "minutes_ago": "{minutes} minutes ago",

--- a/lib/src/screens/details_service_node_page.dart
+++ b/lib/src/screens/details_service_node_page.dart
@@ -105,18 +105,23 @@ class DetailsServiceNodePage extends BasePage {
                         padding: EdgeInsets.all(20),
                         width: 600,
                         child: Column(
-                          children: [
-                            Text(S.of(context).next_reward,
-                                style: TextStyle(fontSize: 30)),
-                            Text(
-                                S
+                          children: contribution.totalContributed / 1000000000 < 15000
+			    ? [
+				Text(S.of(context).awaiting_contributions,
+				  style: TextStyle(fontSize: 30))
+			      ]
+                            : [
+				Text(S.of(context).next_reward,
+				  style: TextStyle(fontSize: 30)),
+				Text(
+				  S
                                     .of(context)
                                     .estimated_reward_block(nextReward),
-                                style: TextStyle(fontSize: 20)),
-                            Text(
-                                "~ ${DateFormat.yMMMd(localeName).add_jms().format(estimateFutureDateForHeight(nextReward))}",
-                                style: TextStyle(fontSize: 20))
-                          ],
+				  style: TextStyle(fontSize: 20)),
+				Text(
+				  "~ ${DateFormat.yMMMd(localeName).add_jms().format(estimateFutureDateForHeight(nextReward))}",
+				  style: TextStyle(fontSize: 20))
+			      ]
                         ),
                       ),
                       color: OxenPalette.teal,


### PR DESCRIPTION
# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dart format lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users


## Issues affected

This fixes a longstanding peeve of mine.

A node that is still awaiting contributions has no next reward scheduled, but we display one as if the node was already active on the network. This patch fixes that and displays an appropriate message instead.