### PR TITLE
Don't count a node awaiting contributions as unhealthy.

### DIFF
--- a/lib/src/screens/dashboard_page.dart
+++ b/lib/src/screens/dashboard_page.dart
@@ -26,7 +26,7 @@ class OperatorStatus {
 
     if (nodes != null) {
       for (final node in nodes) {
-        if (node.active && node.funded)
+        if ((node.active && node.funded) || (!node.active && !node.funded))
           healthyNodes++;
         else
           unhealthyNodes++;


### PR DESCRIPTION
# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dart format lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users


## Issues affected

Those red slices are scary when they're the first thing we see. We really shouldn't count a node that has never been active as an unhealthy node.