### PR TITLE
Add the ability to sort nodes by last uptime proof, oldest first.

### DIFF
--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -101,7 +101,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "settings_dark_theme" : MessageLookupByLibrary.simpleMessage("Dark Theme"),
     "settings_language" : MessageLookupByLibrary.simpleMessage("Language"),
     "settings_light_theme" : MessageLookupByLibrary.simpleMessage("Light Theme"),
-    "settings_order_by" : MessageLookupByLibrary.simpleMessage("Oder Nodes by"),
+    "settings_order_by" : MessageLookupByLibrary.simpleMessage("Order Nodes by"),
     "settings_service_nodes" : MessageLookupByLibrary.simpleMessage("Service Nodes"),
     "settings_title_app" : MessageLookupByLibrary.simpleMessage("App"),
     "settings_title_general" : MessageLookupByLibrary.simpleMessage("General"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -765,10 +765,10 @@ class S {
     );
   }
 
-  /// `Oder Nodes by`
+  /// `Order Nodes by`
   String get settings_order_by {
     return Intl.message(
-      'Oder Nodes by',
+      'Order Nodes by',
       name: 'settings_order_by',
       desc: '',
       args: [],

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -80,7 +80,7 @@
   "settings_language": "Language",
   "settings_daemon": "Daemon",
   "settings_service_nodes": "Service Nodes",
-  "settings_order_by": "Oder Nodes by",
+  "settings_order_by": "Order Nodes by",
   "settings_dark_theme": "Dark Theme",
   "settings_light_theme": "Light Theme",
 

--- a/lib/src/screens/dashboard_page.dart
+++ b/lib/src/screens/dashboard_page.dart
@@ -95,17 +95,23 @@ class DashboardPage extends BasePage {
                   operatorStatus.healthyNodes, operatorStatus.totalNodes));
 
       if (nodeSyncStatus.nodes != null) {
-        if (settingsStore.dashboardOrderBy == DashboardOrderBy.NAME) {
-          nodeSyncStatus.nodes.sort((a, b) {
-            var aN = nodes.values
-                .firstWhere((e) => e.publicKey == b.nodeInfo.publicKey)
-                .name.toUpperCase();
-            var bN = nodes.values
-                .firstWhere((e) => e.publicKey == a.nodeInfo.publicKey)
-                .name.toUpperCase();
-            return bN.compareTo(aN);
-          });
-        } else {
+        switch (settingsStore.dashboardOrderBy) {
+	  case DashboardOrderBy.NAME:
+	    nodeSyncStatus.nodes.sort((a, b) {
+              var aN = nodes.values
+                  .firstWhere((e) => e.publicKey == b.nodeInfo.publicKey)
+                  .name.toUpperCase();
+              var bN = nodes.values
+                  .firstWhere((e) => e.publicKey == a.nodeInfo.publicKey)
+                  .name.toUpperCase();
+              return bN.compareTo(aN);
+	    });
+	    break;
+	  case DashboardOrderBy.LAST_UPTIME_PROOF:
+            nodeSyncStatus.nodes.sort((a, b) =>
+                a.lastUptimeProof.compareTo(b.lastUptimeProof));
+	    break;
+	  case DashboardOrderBy.NAME:
           nodeSyncStatus.nodes.sort((a, b) =>
               a.lastReward.blockHeight.compareTo(b.lastReward.blockHeight));
         }

--- a/lib/src/utils/dashboard_sort_order.dart
+++ b/lib/src/utils/dashboard_sort_order.dart
@@ -2,9 +2,10 @@ import 'package:oxen_service_node/generated/l10n.dart';
 
 class DashboardOrderBy {
   static const NEXT_REWARD = const DashboardOrderBy._('NEXT_REWARD');
+  static const LAST_UPTIME_PROOF = const DashboardOrderBy._('LAST_UPTIME_PROOF');
   static const NAME = const DashboardOrderBy._('NAME');
 
-  static get values => [NEXT_REWARD, NAME];
+  static get values => [NEXT_REWARD, LAST_UPTIME_PROOF, NAME];
 
   final String name;
 
@@ -21,6 +22,8 @@ class DashboardOrderBy {
     switch (this) {
       case NEXT_REWARD:
         return S.current.dashboard_order_by_next_reward;
+      case LAST_UPTIME_PROOF:
+        return S.current.last_uptime_proof;
       case NAME:
         return S.current.dashboard_order_by_name;
     }


### PR DESCRIPTION
# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dart format lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users

Adding the ability to sort nodes by last uptime proof, from oldest to most recent, makes it possibly to very quickly see whether any are already over the 60 minute mark, which can be an early indicator of a problem.