### PR TITLE
Allow hyphens in the hostnames of RPC nodes.

### DIFF
--- a/lib/src/screens/add_new_daemon_page.dart
+++ b/lib/src/screens/add_new_daemon_page.dart
@@ -46,7 +46,7 @@ class AddNewDaemonPageBodyState extends State<AddNewDaemonPageBody> {
 
   String _validateNodeAddress(String value) {
     const pattern =
-        '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\$|^[0-9a-zA-Z.]+\$';
+        '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\$|^[-0-9a-zA-Z.]{1,253}\$';
     final isValid = RegExp(pattern).hasMatch(value);
     return isValid ? null : S.current.error_text_daemon_address;
   }


### PR DESCRIPTION
Restrict the hostname length to 253 characters, as per RFC1035.

# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dart format lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users

The app currently rejects RPC node hostnames that contain a hyphen. This fixes that.

We also reject hostnames > 253 characters, as per the relevant RFC.