### PR TITLE
This is the new canonical list of RPC hosts as used by the OPTF.

### DIFF
--- a/assets/daemon_list.yml
+++ b/assets/daemon_list.yml
@@ -1,14 +1,14 @@
 -
-  uri: public.loki.foundation:22023
+  uri: public-na.optf.ngo:22023
   is_default: true
 -
-  uri: imaginary.stream:22023
+  uri: public-eu.optf.ngo:22023
   is_default: false
 -
   uri: nodes.hashvault.pro:22023
   is_default: false
 -
-  uri: explorer.loki.aussie-pools.com:18081
+  uri: explorer.oxen.aussie-pools.com:18081
   is_default: false
 -
   uri: oxen-rpc.caliban.org:22023


### PR DESCRIPTION
# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-service-node-operator/tree/trunk) branch
* [x] Ran ´dart format lib/src´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users

The RPC node list used by the OPTF for the mobile Oxen wallet is leading. [The desktop wallet is being altered to use the same list](https://github.com/oxen-io/oxen-electron-gui-wallet/pull/315/commits/ef4e62d8b072cc0b06ec00731b56530d0ebb73e5), so we should do the same.
